### PR TITLE
Add optional func to set the span's error tag flag

### DIFF
--- a/ginhttp/server_test.go
+++ b/ginhttp/server_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 )
 
@@ -96,7 +96,7 @@ func TestSpanObserverOption(t *testing.T) {
 				t.Fatalf("got %s operation name, expected %s", got, want)
 			}
 
-			defaultLength := 5
+			defaultLength := 6
 			if len(spans[0].Tags()) != len(testCase.Tags)+defaultLength {
 				t.Fatalf("got tag length %d, expected %d", len(spans[0].Tags()), len(testCase.Tags))
 			}


### PR DESCRIPTION
Some APM providers (like Datadog) require the span error tag to be set in order to properly display the status of the trace.
This PR will add a new MWOption function that allows to set the flag based on gin's context.
![Status](https://user-images.githubusercontent.com/1855079/49593344-4046d180-f96b-11e8-9277-6ce2033b058c.png)