### PR TITLE
Support customising the http.url tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,16 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
 
 install:
-  - go get golang.org/x/tools/cmd/goimports
   - go get github.com/gin-gonic/gin
   - go get github.com/opentracing/opentracing-go
   - go get github.com/uber/jaeger-client-go
   - go get github.com/uber/jaeger-client-go/zipkin
 
 script:
-  - test -z $(goimports -l .)
+  - test -z $(gofmt -l .)
   - go test -v -cover -race ./...


### PR DESCRIPTION
This may be useful where the url contains sensitive information.

This allows url tags such as:

 http.url: https://Aladdin:OpenSesame@www.example.com/index.html
 http.url: https://www.example.com?foo=bar&token=123

to be redacted:

 http.url: https://xxx:xxx@www.example.com/index.html
 http.url: https://www.example.com?foo=bar&token=***

This is a "backport" of:

 https://github.com/opentracing-contrib/go-stdlib/pull/37