### PR TITLE
fix panic risk in func Middleware

### DIFF
--- a/ginhttp/server.go
+++ b/ginhttp/server.go
@@ -96,9 +96,11 @@ func Middleware(tr opentracing.Tracer, options ...MWOption) gin.HandlerFunc {
 		c.Request = c.Request.WithContext(
 			opentracing.ContextWithSpan(c.Request.Context(), sp))
 
-		c.Next()
+		defer func() {
+			ext.HTTPStatusCode.Set(sp, uint16(c.Writer.Status()))
+			sp.Finish()
+		}()
 
-		ext.HTTPStatusCode.Set(sp, uint16(c.Writer.Status()))
-		sp.Finish()
+		c.Next()
 	}
 }


### PR DESCRIPTION
In func Middleware, `c.Next` would be panic, then span.Finish will not be executed.

```go
//...
	return func(c *gin.Context) {
		carrier := opentracing.HTTPHeadersCarrier(c.Request.Header)
		ctx, _ := tr.Extract(opentracing.HTTPHeaders, carrier)
		op := opts.opNameFunc(c.Request)
		sp := tr.StartSpan(op, ext.RPCServerOption(ctx))
		ext.HTTPMethod.Set(sp, c.Request.Method)
		ext.HTTPUrl.Set(sp, opts.urlTagFunc(c.Request.URL))
		opts.spanObserver(sp, c.Request)

		// set component name, use "net/http" if caller does not specify
		componentName := opts.componentName
		if componentName == "" {
			componentName = defaultComponentName
		}
		ext.Component.Set(sp, componentName)
		c.Request = c.Request.WithContext(
			opentracing.ContextWithSpan(c.Request.Context(), sp))

		c.Next()

		ext.HTTPStatusCode.Set(sp, uint16(c.Writer.Status()))
		sp.Finish()
	}
//...
```